### PR TITLE
docs: Replace dataspaceconnector occurrencies with dataspacecomponents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@ Closes # <-- _insert Issue number if one exists_
 
 - [ ] added/updated copyright headers?
 - [ ] documented code?
-- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
+- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -16,6 +16,6 @@ jobs:
           issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
           pr-message: >-
             'We are always happy to welcome new contributors :heart: To make things easier for everyone, please
-            - make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md),
+            - make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/blob/main/CONTRIBUTING.md),
             - check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
             - relate this pull request to an existing issue or discussion.'

--- a/.github/workflows/scan-pull-request.yml
+++ b/.github/workflows/scan-pull-request.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           # Match pull request titles conventional commit syntax (https://www.conventionalcommits.org/en/v1.0.0/)
           # (online tool for regex quick check: https://regex101.com/r/V5J8kh/1)
-          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+((,|\/|\\)?\s?\w+)+\))?!?: [\S ]{1,49}[^\.]$'
+          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+((,|\/|\\)?\s?\w+)+\))?!?: [\S ]{1,80}[^\.]$'
           allowed_prefixes: 'build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test'
           prefix_case_sensitive: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "docs/submodule/Collateral"]
 	path = docs/submodule/Collateral
-	url = https://github.com/eclipse-dataspaceconnector/Collateral.git
+	url = https://github.com/eclipse-dataspacecomponents/Collateral.git
 [submodule "docs/submodule/Connector"]
 	path = docs/submodule/Connector
-	url = https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git
+	url = https://github.com/eclipse-dataspacecomponents/DataSpaceConnector.git
 [submodule "docs/submodule/DataDashboard"]
 	path = docs/submodule/DataDashboard
-	url = https://github.com/eclipse-dataspaceconnector/DataDashboard.git
+	url = https://github.com/eclipse-dataspacecomponents/DataDashboard.git
 [submodule "docs/submodule/FederatedCatalog"]
 	path = docs/submodule/FederatedCatalog
-	url = https://github.com/eclipse-dataspaceconnector/FederatedCatalog.git
+	url = https://github.com/eclipse-dataspacecomponents/FederatedCatalog.git
 [submodule "docs/submodule/IdentityHub"]
 	path = docs/submodule/IdentityHub
-	url = https://github.com/eclipse-dataspaceconnector/IdentityHub.git
+	url = https://github.com/eclipse-dataspacecomponents/IdentityHub.git
 [submodule "docs/submodule/MinimumViableDataspace"]
 	path = docs/submodule/MinimumViableDataspace
-	url = https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace.git
+	url = https://github.com/eclipse-dataspacecomponents/MinimumViableDataspace.git
 [submodule "docs/submodule/Publications"]
 	path = docs/submodule/Publications
-	url = https://github.com/eclipse-dataspaceconnector/Publications.git
+	url = https://github.com/eclipse-dataspacecomponents/Publications.git
 [submodule "docs/submodule/RegistrationService"]
 	path = docs/submodule/RegistrationService
-	url = https://github.com/eclipse-dataspaceconnector/RegistrationService.git
+	url = https://github.com/eclipse-dataspacecomponents/RegistrationService.git
 [submodule "docs/submodule/GradlePlugins"]
 	path = docs/submodule/GradlePlugins
-	url = https://github.com/eclipse-dataspaceconnector/GradlePlugins.git
+	url = https://github.com/eclipse-dataspacecomponents/GradlePlugins.git
 [submodule "docs/submodule/TrustFrameworkAdoption"]
 	path = docs/submodule/TrustFrameworkAdoption
-	url = https://github.com/eclipse-dataspaceconnector/TrustFrameworkAdoption
+	url = https://github.com/eclipse-dataspacecomponents/TrustFrameworkAdoption

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the documentation framework for providing the documentation files of all EDC
 repositories as a [GitHub page](https://docs.github.com/en/pages).
 
-The pages are deployed from the `/docs` sub-directory to <https://eclipse-dataspaceconnector.github.io/docs>.
+The pages are deployed from the `/docs` sub-directory to <https://eclipse-dataspacecomponents.github.io/docs>.
 
 ## Local Deployment
 
@@ -11,7 +11,7 @@ If you want to add content or change configurations, please refer to the [offici
 
 For a local deployment, install [Node.js](https://nodejs.org/), check out this repository, and run Docsify:
 ```commandline
-$ git clone https://github.com/eclipse-dataspaceconnector/docs.git
+$ git clone https://github.com/eclipse-dataspacecomponents/docs.git
 $ cd docs
 $ npm i docsify-cli -g
 $ docsify serve docs

--- a/docs/404.md
+++ b/docs/404.md
@@ -5,4 +5,4 @@ As this GitHub pages mainly link to markdown files of external repositories, thi
 - Not (yet) existent content
 - Moved content (e.g., classes)
 
-Please be aware of this when [creating an issue](https://github.com/eclipse-dataspaceconnector/docs/issues).
+Please be aware of this when [creating an issue](https://github.com/eclipse-dataspacecomponents/docs/issues).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-Data spaces allow organizations to securely share data with others. They enable data cooperation in a multi-cloud 
+Data spaces allow organizations to securely share data with others. They enable data cooperation in a multi-cloud
 federation by focusing on identity, trust, sovereignty, and interoperability.
 
 - Identity: Each participant remains in control of their identity.
@@ -60,39 +60,39 @@ more customized environments, while avoiding any intellectual property rights (I
 
 ## Statement: EDC vs. DSC
 
-_Also to be read on [GitHub](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/1037)._
+_Also to be read on [GitHub](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/discussions/1037)._
 
-**The Eclipse Dataspace Components expand and improve the Dataspace Connector (DSC) as a follow-up development 
-by an OSS community that is being contributed to the various initiatives that are involved in building data spaces. 
+**The Eclipse Dataspace Components expand and improve the Dataspace Connector (DSC) as a follow-up development
+by an OSS community that is being contributed to the various initiatives that are involved in building data spaces.
 Both connectors do _not_ have the same codebase, but follow the same ideas of sovereign data spaces.**
 
-The DSC is a component previously developed by Fraunhofer ISST. The goal was to build an IDS-compliant connector 
-driven by a community (e.g., from initiatives as Catena-X, Gaia-X, Mobility Data Space) as OSS to foster distribution 
-and usage. While some discussions with several partner organizations begin/mid last year, it became very clear that 
-the underlying governance and rules for contributions did not fit the requirements to form such a community and work 
+The DSC is a component previously developed by Fraunhofer ISST. The goal was to build an IDS-compliant connector
+driven by a community (e.g., from initiatives as Catena-X, Gaia-X, Mobility Data Space) as OSS to foster distribution
+and usage. While some discussions with several partner organizations begin/mid last year, it became very clear that
+the underlying governance and rules for contributions did not fit the requirements to form such a community and work
 on the code together due to questions regarding intellectual property (IP), licensing, etc.
 
-As a solution, partners agreed in June '21 to create a project within the Eclipse Foundation (EF), since EF provides 
+As a solution, partners agreed in June '21 to create a project within the Eclipse Foundation (EF), since EF provides
 clear governance structures and rules allowing exactly the collaboration and community building, it was aimed for.
-While the transfer process and meetings with initial committers (among others), the architecture was rethought to 
-directly address future requirements in terms of applicability, robustness, scaling, etc. A much-discussed issue 
-dealt with the limitation to a single data protocol such as the IDS vs. a solution that can support multiple such 
-protocols. The decision fell on the latter and so the EDC is now developed based on a new architecture and design 
-principles but based on available parts (like the DSC) that were transferred as initial contributions to the EF 
-(see the [project's proposal](https://projects.eclipse.org/proposals/eclipse-dataspace-connector)). This time 
-with a [community of various companies](https://projects.eclipse.org/projects/technology.dataspaceconnector/who) 
-that bring in requirements from different initiatives like Catena-X, Eona-X, IDSA, Gaia-X, or MDS, and work on 
-a decentralized data space implementation based on a data space connector that provides capabilities for data 
-exchange and extensibility to various shared service implementations (catalog, identity, usage control, logging, etc.) 
-through interfaces. Thereby, the EDC can support IDS(A)-based components like the DAPS (Identity), or Metadata Broker 
-(Catalog) as well as other approaches like WEB-DID (Identity) or Federated Catalog (Catalog). All with the same core 
-to enable organizations to use a single technology to participate in multiple data spaces/ecosystems/federations in 
+While the transfer process and meetings with initial committers (among others), the architecture was rethought to
+directly address future requirements in terms of applicability, robustness, scaling, etc. A much-discussed issue
+dealt with the limitation to a single data protocol such as the IDS vs. a solution that can support multiple such
+protocols. The decision fell on the latter and so the EDC is now developed based on a new architecture and design
+principles but based on available parts (like the DSC) that were transferred as initial contributions to the EF
+(see the [project's proposal](https://projects.eclipse.org/proposals/eclipse-dataspace-connector)). This time
+with a [community of various companies](https://projects.eclipse.org/projects/technology.edc/who)
+that bring in requirements from different initiatives like Catena-X, Eona-X, IDSA, Gaia-X, or MDS, and work on
+a decentralized data space implementation based on a data space connector that provides capabilities for data
+exchange and extensibility to various shared service implementations (catalog, identity, usage control, logging, etc.)
+through interfaces. Thereby, the EDC can support IDS(A)-based components like the DAPS (Identity), or Metadata Broker
+(Catalog) as well as other approaches like WEB-DID (Identity) or Federated Catalog (Catalog). All with the same core
+to enable organizations to use a single technology to participate in multiple data spaces/ecosystems/federations in
 parallel.
 
 ## Correlating projects
 
 **Please note**: Not every project may be mentioned here. If you want to add one, please feel free to open a PR
-or provide us with information via an [adoption request](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/new?assignees=&labels=adoption&template=adoption_request.md&title=Adoption+Request).
+or provide us with information via an [adoption request](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/issues/new?assignees=&labels=adoption&template=adoption_request.md&title=Adoption+Request).
 
 | Name       | Description |
 | :--------- | :---------- |

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,16 +1,16 @@
 ![logo](_media/icon.png)
 
-# Eclipse Dataspace Components 
+# Eclipse Dataspace Components
 
 [comment]: <> (<small>1.0.0</small>)
 
 > Scalable cloud data space services.
 
-- Modular and extensible 
-- Asynchronous and highly available 
+- Modular and extensible
+- Asynchronous and highly available
 - Secure and sovereign data transfer
 
-[GitHub](https://github.com/eclipse-dataspaceconnector)
+[GitHub](https://github.com/eclipse-dataspacecomponents)
 [Getting Started](README.md)
 
 ![color](#f0f0f0)

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,5 +1,5 @@
-* [Contact Us](https://projects.eclipse.org/projects/technology.dataspaceconnector/contact)
-* [EF Project](https://projects.eclipse.org/projects/technology.dataspaceconnector)
+* [Contact Us](https://projects.eclipse.org/projects/technology.edc/contact)
+* [EF Project](https://projects.eclipse.org/projects/technology.edc)
 * [Homepage](https://dataspace-connector.io/)
 * [YouTube](https://www.youtube.com/channel/UCYmjEHtMSzycheBB4AeITHg)
 

--- a/docs/hands-on.md
+++ b/docs/hands-on.md
@@ -3,5 +3,5 @@
 - [Build and run a monolithic connector](submodule/Connector/docs/developer/build-your-own-connector.md)
 - [Connector Samples](submodule/Connector/samples/)
 - [Minimum Viable Dataspace](submodule/MinimumViableDataspace/)
-- [Open API Specification](https://eclipse-dataspaceconnector.github.io/docs/submodule/Connector/docs/swaggerui/index.html)
+- [Open API Specification](https://eclipse-dataspacecomponents.github.io/docs/submodule/Connector/docs/swaggerui/index.html)
 - [YouTube Playlist](https://youtube.com/playlist?list=PLw-f_YoTxWJVVPkuj1vDb6tLPM2_Cm1hR)

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
         remoteMarkdown: {
           tag: 'remoteMarkdownUrl',
         },
-        repo: 'eclipse-dataspaceconnector',
+        repo: 'eclipse-dataspacecomponents',
         search: {
           noData: {
             '/': 'No results!',

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eclipse-dataspaceconnector/docs.git"
+    "url": "git+https://github.com/eclipse-dataspacecomponents/docs.git"
   },
   "lint-staged": {
     "*.js": "eslint --fix"


### PR DESCRIPTION
## What this PR changes/adds

Replace 
- all the `eclipse-dataspaceconnector` occurrencies with `eclipse-dataspacecomponents`
- all the `technology.dataspaceconnector` occurrencies with `technolody.edc`

## Why it does that

rebranding

## Further notes

- aligned pr title length with other repositories

## Linked Issue(s)

Closes #22

## Checklist

- [x] added/updated copyright headers?
- [x] documented code?
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
