### PR TITLE
docs: Further url updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@ Closes # <-- _insert Issue number if one exists_
 
 - [ ] added/updated copyright headers?
 - [ ] documented code?
-- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
+- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -16,6 +16,6 @@ jobs:
           issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
           pr-message: >-
             'We are always happy to welcome new contributors :heart: To make things easier for everyone, please
-            - make sure to follow our [contribution guidelines](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/blob/main/CONTRIBUTING.md),
+            - make sure to follow our [contribution guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md),
             - check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
             - relate this pull request to an existing issue or discussion.'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "docs/submodule/Collateral"]
 	path = docs/submodule/Collateral
-	url = https://github.com/eclipse-dataspacecomponents/Collateral.git
+	url = https://github.com/eclipse-edc/Collateral.git
 [submodule "docs/submodule/Connector"]
 	path = docs/submodule/Connector
-	url = https://github.com/eclipse-dataspacecomponents/DataSpaceConnector.git
+	url = https://github.com/eclipse-edc/DataSpaceConnector.git
 [submodule "docs/submodule/DataDashboard"]
 	path = docs/submodule/DataDashboard
-	url = https://github.com/eclipse-dataspacecomponents/DataDashboard.git
+	url = https://github.com/eclipse-edc/DataDashboard.git
 [submodule "docs/submodule/FederatedCatalog"]
 	path = docs/submodule/FederatedCatalog
-	url = https://github.com/eclipse-dataspacecomponents/FederatedCatalog.git
+	url = https://github.com/eclipse-edc/FederatedCatalog.git
 [submodule "docs/submodule/IdentityHub"]
 	path = docs/submodule/IdentityHub
-	url = https://github.com/eclipse-dataspacecomponents/IdentityHub.git
+	url = https://github.com/eclipse-edc/IdentityHub.git
 [submodule "docs/submodule/MinimumViableDataspace"]
 	path = docs/submodule/MinimumViableDataspace
-	url = https://github.com/eclipse-dataspacecomponents/MinimumViableDataspace.git
+	url = https://github.com/eclipse-edc/MinimumViableDataspace.git
 [submodule "docs/submodule/Publications"]
 	path = docs/submodule/Publications
-	url = https://github.com/eclipse-dataspacecomponents/Publications.git
+	url = https://github.com/eclipse-edc/Publications.git
 [submodule "docs/submodule/RegistrationService"]
 	path = docs/submodule/RegistrationService
-	url = https://github.com/eclipse-dataspacecomponents/RegistrationService.git
+	url = https://github.com/eclipse-edc/RegistrationService.git
 [submodule "docs/submodule/GradlePlugins"]
 	path = docs/submodule/GradlePlugins
-	url = https://github.com/eclipse-dataspacecomponents/GradlePlugins.git
+	url = https://github.com/eclipse-edc/GradlePlugins.git
 [submodule "docs/submodule/TrustFrameworkAdoption"]
 	path = docs/submodule/TrustFrameworkAdoption
-	url = https://github.com/eclipse-dataspacecomponents/TrustFrameworkAdoption
+	url = https://github.com/eclipse-edc/TrustFrameworkAdoption

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the documentation framework for providing the documentation files of all EDC
 repositories as a [GitHub page](https://docs.github.com/en/pages).
 
-The pages are deployed from the `/docs` sub-directory to <https://eclipse-dataspacecomponents.github.io/docs>.
+The pages are deployed from the `/docs` sub-directory to <https://eclipse-edc.github.io/docs>.
 
 ## Local Deployment
 
@@ -11,7 +11,7 @@ If you want to add content or change configurations, please refer to the [offici
 
 For a local deployment, install [Node.js](https://nodejs.org/), check out this repository, and run Docsify:
 ```commandline
-$ git clone https://github.com/eclipse-dataspacecomponents/docs.git
+$ git clone https://github.com/eclipse-edc/docs.git
 $ cd docs
 $ npm i docsify-cli -g
 $ docsify serve docs

--- a/docs/404.md
+++ b/docs/404.md
@@ -5,4 +5,4 @@ As this GitHub pages mainly link to markdown files of external repositories, thi
 - Not (yet) existent content
 - Moved content (e.g., classes)
 
-Please be aware of this when [creating an issue](https://github.com/eclipse-dataspacecomponents/docs/issues).
+Please be aware of this when [creating an issue](https://github.com/eclipse-edc/docs/issues).

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ more customized environments, while avoiding any intellectual property rights (I
 
 ## Statement: EDC vs. DSC
 
-_Also to be read on [GitHub](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/discussions/1037)._
+_Also to be read on [GitHub](https://github.com/eclipse-edc/DataSpaceConnector/discussions/1037)._
 
 **The Eclipse Dataspace Components expand and improve the Dataspace Connector (DSC) as a follow-up development
 by an OSS community that is being contributed to the various initiatives that are involved in building data spaces.
@@ -92,7 +92,7 @@ parallel.
 ## Correlating projects
 
 **Please note**: Not every project may be mentioned here. If you want to add one, please feel free to open a PR
-or provide us with information via an [adoption request](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/issues/new?assignees=&labels=adoption&template=adoption_request.md&title=Adoption+Request).
+or provide us with information via an [adoption request](https://github.com/eclipse-edc/DataSpaceConnector/issues/new?assignees=&labels=adoption&template=adoption_request.md&title=Adoption+Request).
 
 | Name       | Description |
 | :--------- | :---------- |

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -10,7 +10,7 @@
 - Asynchronous and highly available
 - Secure and sovereign data transfer
 
-[GitHub](https://github.com/eclipse-dataspacecomponents)
+[GitHub](https://github.com/eclipse-edc)
 [Getting Started](README.md)
 
 ![color](#f0f0f0)

--- a/docs/hands-on.md
+++ b/docs/hands-on.md
@@ -3,5 +3,5 @@
 - [Build and run a monolithic connector](submodule/Connector/docs/developer/build-your-own-connector.md)
 - [Connector Samples](submodule/Connector/samples/)
 - [Minimum Viable Dataspace](submodule/MinimumViableDataspace/)
-- [Open API Specification](https://eclipse-dataspacecomponents.github.io/docs/submodule/Connector/docs/swaggerui/index.html)
+- [Open API Specification](https://eclipse-edc.github.io/docs/submodule/Connector/docs/swaggerui/index.html)
 - [YouTube Playlist](https://youtube.com/playlist?list=PLw-f_YoTxWJVVPkuj1vDb6tLPM2_Cm1hR)

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
         remoteMarkdown: {
           tag: 'remoteMarkdownUrl',
         },
-        repo: 'eclipse-dataspacecomponents',
+        repo: 'eclipse-edc',
         search: {
           noData: {
             '/': 'No results!',

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eclipse-dataspacecomponents/docs.git"
+    "url": "git+https://github.com/eclipse-edc/docs.git"
   },
   "lint-staged": {
     "*.js": "eslint --fix"


### PR DESCRIPTION
## What this PR changes/adds

Adapt to the definitive `eclipse-edc` organization.
Renamed occurrencies of `DataSpaceConnector` to `Connector` as well

## Why it does that

rebranding

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added/updated copyright headers?
- [x] documented code?
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspacecomponents/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
