### PR TITLE
chore: update link to samples

### DIFF
--- a/docs/hands-on.md
+++ b/docs/hands-on.md
@@ -1,7 +1,7 @@
 # Hands-on
 
 - [Build and run a monolithic connector](submodule/Connector/docs/developer/build-your-own-connector.md)
-- [Connector Samples](submodule/Connector/samples/)
+- [Samples repository](https://github.com/eclipse-edc/Samples)
 - [Minimum Viable Dataspace](submodule/MinimumViableDataspace/)
 - [Management API Specification (SwaggerHub)](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api)
 - [Control API Specification (SwaggerHub)](https://app.swaggerhub.com/apis/eclipse-edc-bot/control-api)


### PR DESCRIPTION
## What this PR changes/adds

Updates the link to the samples in `hands-on.md` to point to the new [samples repository](https://github.com/eclipse-edc/Samples).

## Why it does that

The samples will be removed from the connector repository.

## Checklist

- [ ] added/updated copyright headers?
- [ ] documented code?
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
