### PR TITLE
fix: replace unexpected value in discord webhook workflow

### DIFF
--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   trigger-workflow:
     uses: eclipse-edc/.github/.github/workflows/discord-webhook.yml@main
-    inputs:
+    with:
       event-name: ${{ github.event_name }}
       event: ${{ github.event }}
       repository: ${{ github.repository }}


### PR DESCRIPTION
## What this PR changes/adds

Replaces `inputs` with `with`.

## Why it does that

Resolve error 
> The workflow is not valid. .github/workflows/discord-webhook.yml (Line: 13, Col: 5): Unexpected value 'inputs'

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
