### PR TITLE
feat: add .github repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "docs/submodule/TrustFrameworkAdoption"]
 	path = docs/submodule/TrustFrameworkAdoption
 	url = https://github.com/eclipse-edc/TrustFrameworkAdoption
+[submodule "docs/submodule/GitHub"]
+	path = docs/submodule/GitHub
+	url = https://github.com/eclipse-edc/.github.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/eclipse-edc/GradlePlugins.git
 [submodule "docs/submodule/TrustFrameworkAdoption"]
 	path = docs/submodule/TrustFrameworkAdoption
-	url = https://github.com/eclipse-edc/TrustFrameworkAdoption
+	url = https://github.com/eclipse-edc/TrustFrameworkAdoption.git
 [submodule "docs/submodule/GitHub"]
 	path = docs/submodule/GitHub
 	url = https://github.com/eclipse-edc/.github.git

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ $ docsify serve docs
 
 ## Contributing
 
-See [how to contribute](docs/submodule/Connector/CONTRIBUTING.md).
+See [how to contribute](docs/submodule/GitHub/CONTRIBUTING.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ parallel.
 ## Correlating projects
 
 **Please note**: Not every project may be mentioned here. If you want to add one, please feel free to open a PR
-or provide us with information via an [adoption request](https://github.com/eclipse-edc/DataSpaceConnector/issues/new?assignees=&labels=adoption&template=adoption_request.md&title=Adoption+Request).
+or provide us with information via an [adoption request](submodule/GitHub/contributing/adoption.md).
 
 | Name       | Description |
 | :--------- | :---------- |
@@ -100,4 +100,4 @@ or provide us with information via an [adoption request](https://github.com/ecli
 | Catena-X   | Uses the EDC as Connector component to build a data space between participants |
 | Tractus-X  | Eclipse Foundation OSS project initiated by Catena-X consortia, where specific (Catena-X related) EDC-extensions can be implemented under clear governance and rules |
 
-To see EDC adoptions, please take a look at our [known friends](submodule/Connector/known_friends.md) list.
+To see EDC adoptions, please take a look at our [known friends](submodule/GitHub/KNOWN_FRIENDS.md) list.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,8 +8,8 @@ and https://github.com/docsifyjs/docsify/issues/1139)
 - <a href="#/README">Home</a>
 
 - Getting Started
-  - <a href="#/submodule/Connector/known_friends.md">Adoptions</a>
-  - <a href="#/submodule/Connector/CONTRIBUTING.md">Contributing</a>
+  - <a href="#/submodule/GitHub/KNOWN_FRIENDS.md">Adoptions</a>
+  - <a href="#/submodule/GitHub/CONTRIBUTING.md">Contributing</a>
   - <a href="#/hands-on.md">Hands-on</a>
 
 - Components


### PR DESCRIPTION
## What this PR changes/adds

Adds .github repo as submodule. Replaces references to Connector documentation with links to .github.

## Why it does that

Follow changes in eclipse-edc/Connector.

## Linked Issue(s)

Relates eclipse-edc/Connector#3033

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
