### PR TITLE
docs: add TOC for the developer handbook

### DIFF
--- a/docs/developer/developer-handbook.md
+++ b/docs/developer/developer-handbook.md
@@ -1,4 +1,4 @@
-# EDC Developer Handbook
+# Developer's Handbook
 
 <!-- TOC -->
 * [EDC Developer Handbook](#edc-developer-handbook)

--- a/docs/developer/developer-handbook.md
+++ b/docs/developer/developer-handbook.md
@@ -1,0 +1,93 @@
+# EDC Developer Handbook
+
+<!-- TOC -->
+* [EDC Developer Handbook](#edc-developer-handbook)
+  * [Introduction](#introduction)
+  * [Building your first connector](#building-your-first-connector)
+    * [Seed some data](#seed-some-data)
+    * [Perform a data transfer](#perform-a-data-transfer)
+  * [The control plane - core concepts](#the-control-plane---core-concepts)
+    * [API objects in detail](#api-objects-in-detail)
+    * [State machines of EDC](#state-machines-of-edc)
+    * [The extension model](#the-extension-model)
+    * [Dependency Injection à la EDC](#dependency-injection-à-la-edc)
+    * [Policy scopes and evaluation](#policy-scopes-and-evaluation)
+  * [The data plane](#the-data-plane)
+    * [Data plane selectors](#data-plane-selectors)
+    * [Write your own DataSink and DataSource](#write-your-own-datasink-and-datasource)
+    * [The Control API](#the-control-api)
+  * [Advanced concepts](#advanced-concepts)
+    * [Events and callbacks](#events-and-callbacks)
+    * [The EDC JUnit framework](#the-edc-junit-framework)
+    * [Automatic documentation](#automatic-documentation)
+    * [Customize the build](#customize-the-build)
+<!-- TOC -->
+
+## Introduction
+
+--> states the intended audience, required pre-existing knowledge, required tools, etc.
+
+## Building your first connector
+--> link to one of the samples
+
+### Seed some data
+
+--> use postman, or even just curl
+
+### Perform a data transfer
+--> actually launches another connector, shows a data exchange -> link to samples
+
+## The control plane - core concepts
+
+### API objects in detail
+
+--> explains Assets, Policies, Contract Definitions, etc. from an external API perspective. mentions JSON-LD and related
+specs (ODRL, DCAT)
+
+### State machines of EDC
+
+--> gives an overview of the state machines to understand asynchronicity and why some APIs only return IDs
+
+### The extension model
+
+--> how to write your own first extension, explains plug-points points, metamodel annotations, SPIs, etc
+
+### Dependency Injection à la EDC
+
+--> explains how a custom extension can inject and provide objects
+
+### Policy scopes and evaluation
+
+## The data plane
+
+### Data plane selectors
+
+--> explains how dataplane selection works and how devs can register a dataplane with the selector
+
+### Write your own DataSink and DataSource
+
+--> link to samples?
+
+### The Control API
+
+--> explains the usage of the control api, in case people want to write their own data plane
+
+## Advanced concepts
+
+### Events and callbacks
+
+--> shows how to hook into
+
+### The EDC JUnit framework
+
+--> explains how devs can leverage the In-Mem runtime feature, the dependency-injection extension, all the different
+tags, the postgres extension, etc.
+
+### Automatic documentation
+
+--> explains what automatic documentation is, how to leverage it, how to download the EDC autodoc manifests and how to
+merge them with the downstream docs
+
+### Customize the build
+
+--> shows how to configure and influence the build

--- a/docs/developer/developer-handbook.md
+++ b/docs/developer/developer-handbook.md
@@ -3,18 +3,18 @@
 <!-- TOC -->
 * [EDC Developer Handbook](#edc-developer-handbook)
   * [Introduction](#introduction)
-  * [Building your first connector](#building-your-first-connector)
+  * [Building a distribution](#building-a-distribution)
     * [Seed some data](#seed-some-data)
     * [Perform a data transfer](#perform-a-data-transfer)
   * [The control plane - core concepts](#the-control-plane---core-concepts)
     * [API objects in detail](#api-objects-in-detail)
-    * [State machines of EDC](#state-machines-of-edc)
+    * [EDC state machines](#edc-state-machines)
     * [The extension model](#the-extension-model)
-    * [Dependency Injection à la EDC](#dependency-injection-à-la-edc)
+    * [EDC dependency injection](#edc-dependency-injection)
     * [Policy scopes and evaluation](#policy-scopes-and-evaluation)
   * [The data plane](#the-data-plane)
     * [Data plane selectors](#data-plane-selectors)
-    * [Write your own DataSink and DataSource](#write-your-own-datasink-and-datasource)
+    * [Writing a DataSink and DataSource extension](#writing-a-datasink-and-datasource-extension)
     * [The Control API](#the-control-api)
   * [Advanced concepts](#advanced-concepts)
     * [Events and callbacks](#events-and-callbacks)
@@ -27,7 +27,7 @@
 
 --> states the intended audience, required pre-existing knowledge, required tools, etc.
 
-## Building your first connector
+## Building a distribution
 --> link to one of the samples
 
 ### Seed some data
@@ -44,7 +44,7 @@
 --> explains Assets, Policies, Contract Definitions, etc. from an external API perspective. mentions JSON-LD and related
 specs (ODRL, DCAT)
 
-### State machines of EDC
+### EDC state machines
 
 --> gives an overview of the state machines to understand asynchronicity and why some APIs only return IDs
 
@@ -52,7 +52,7 @@ specs (ODRL, DCAT)
 
 --> how to write your own first extension, explains plug-points points, metamodel annotations, SPIs, etc
 
-### Dependency Injection à la EDC
+### EDC dependency injection
 
 --> explains how a custom extension can inject and provide objects
 
@@ -64,7 +64,7 @@ specs (ODRL, DCAT)
 
 --> explains how dataplane selection works and how devs can register a dataplane with the selector
 
-### Write your own DataSink and DataSource
+### Writing a DataSink and DataSource extension
 
 --> link to samples?
 

--- a/docs/developer/developer-handbook.md
+++ b/docs/developer/developer-handbook.md
@@ -1,14 +1,15 @@
 # Developer's Handbook
 
 <!-- TOC -->
-* [EDC Developer Handbook](#edc-developer-handbook)
+* [Developer's Handbook](#developers-handbook)
   * [Introduction](#introduction)
   * [Building a distribution](#building-a-distribution)
     * [Seed some data](#seed-some-data)
     * [Perform a data transfer](#perform-a-data-transfer)
-  * [The control plane - core concepts](#the-control-plane---core-concepts)
+  * [Core concepts](#core-concepts)
+  * [The control plane](#the-control-plane)
     * [API objects in detail](#api-objects-in-detail)
-    * [EDC state machines](#edc-state-machines)
+    * [Control plane state machines](#control-plane-state-machines)
     * [The extension model](#the-extension-model)
     * [EDC dependency injection](#edc-dependency-injection)
     * [Policy scopes and evaluation](#policy-scopes-and-evaluation)
@@ -37,16 +38,20 @@
 ### Perform a data transfer
 --> actually launches another connector, shows a data exchange -> link to samples
 
-## The control plane - core concepts
+## Core concepts
+
+--> lists and explains general building blocks like asynchronicity, to understand why some APIs only return IDs, etc.
+
+## The control plane
 
 ### API objects in detail
 
 --> explains Assets, Policies, Contract Definitions, etc. from an external API perspective. mentions JSON-LD and related
 specs (ODRL, DCAT)
 
-### EDC state machines
+### Control plane state machines
 
---> gives an overview of the state machines to understand asynchronicity and why some APIs only return IDs
+--> gives an overview of the contract negotiation and transfer process state machines 
 
 ### The extension model
 

--- a/docs/developer/developer-handbook.md
+++ b/docs/developer/developer-handbook.md
@@ -56,6 +56,11 @@ specs (ODRL, DCAT)
 ### The extension model
 
 --> how to write your own first extension, explains plug-points points, metamodel annotations, SPIs, etc
+- Authentication/Authorization of the Management API
+- policies and evaluation functions
+- persistence implementations
+- provisioners
+- transaction management (?)
 
 ### EDC dependency injection
 


### PR DESCRIPTION
## What this PR changes/adds

Adds TOC for the developer documentation

## Why it does that

Preparatory work for a more streamlined documentation experience

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
