### PR TITLE
feat: add developer and decision records links on sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -2,26 +2,51 @@
 landing page of this section. Other subsections are placed below and can be linked separately. Feel
 free to add sections and subsections to this sidebar.)
 
-[comment]: <> (Html instead of markdown due to known issues: https://github.com/docsifyjs/docsify/issues/850
-and https://github.com/docsifyjs/docsify/issues/1139)
+- [Home](/README)
 
-- <a href="#/README">Home</a>
+&nbsp;&nbsp;**Getting Started**
+- [Adoptions](/submodule/GitHub/KNOWN_FRIENDS.md)
+- [Contributing](/submodule/GitHub/CONTRIBUTING.md)
+- [Hands-on](/hands-on.md)
 
-- Getting Started
-  - <a href="#/submodule/GitHub/KNOWN_FRIENDS.md">Adoptions</a>
-  - <a href="#/submodule/GitHub/CONTRIBUTING.md">Contributing</a>
-  - <a href="#/hands-on.md">Hands-on</a>
+&nbsp;&nbsp;**Components**
 
-- Components
-  - <a href="#/submodule/Connector/">Connector</a>
-  - <a href="#/submodule/DataDashboard/">Data Dashboard</a>
-  - <a href="#/submodule/FederatedCatalog/">Federated Catalog</a>
-  - <a href="#/submodule/GradlePlugins/">Gradle Plugins</a>
-  - <a href="#/submodule/IdentityHub/">Identity Hub</a>
-  - <a href="#/submodule/MinimumViableDataspace/">Minimum Viable Dataspace</a>
-  - <a href="#/submodule/RegistrationService/">Registration Service</a>
-  - <a href="#/submodule/TrustFrameworkAdoption/">Trust Framework Adoption</a>
+- [Connector](/submodule/Connector/)
+  - [Developer](/submodule/Connector/docs/developer/)
+  - [Decision Records](/submodule/Connector/docs/developer/decision-records/)
 
-- Documents
-  - <a href="#/submodule/Collateral/">Collateral</a>
-  - <a href="#publications.md">Publications</a>
+- [Data Dashboard](/submodule/DataDashboard/)
+  - [Developer](/submodule/DataDashboard/docs/developer/)
+  - [Decision Records](/submodule/DataDashboard/docs/developer/decision-records/)
+
+- [Federated Catalog](/submodule/FederatedCatalog/)
+  - [Developer](/submodule/FederatedCatalog/docs/developer/)
+  - [Decision Records](/submodule/FederatedCatalog/docs/developer/decision-records/)
+
+- [Gradle Plugins](/submodule/GradlePlugins/)
+  - [Developer](/submodule/GradlePlugins/docs/developer/)
+  - [Decision Records](/submodule/GradlePlugins/docs/developer/decision-records/)
+
+- [Identity Hub](/submodule/IdentityHub/)
+  - [Developer](/submodule/IdentityHub/docs/developer/)
+  - [Decision Records](/submodule/IdentityHub/docs/developer/decision-records/)
+
+- [Minimum Viable Dataspace](/submodule/MinimumViableDataspace/)
+  - [Developer](/submodule/MinimumViableDataspace/docs/developer/)
+  - [Decision Records](/submodule/MinimumViableDataspace/docs/developer/decision-records/)
+
+- [Registration Service](/submodule/RegistrationService/)
+  - [Developer](/submodule/RegistrationService/docs/developer/)
+  - [Decision Records](/submodule/RegistrationService/docs/developer/decision-records/)
+
+- [Trust Framework Adoption](/submodule/TrustFrameworkAdoption/)
+  - [Developer](/submodule/TrustFrameworkAdoption/docs/developer/)
+  - [Decision Records](/submodule/TrustFrameworkAdoption/docs/developer/decision-records/)
+
+&nbsp;&nbsp;**Documents**
+
+- [Collateral](/submodule/Collateral/)
+  - [Events](/submodule/Collateral/Events/)
+  - [Latest Presentations](/submodule/Collateral/Latest%20Presentations/)
+  - [Work Content](/submodule/Collateral/Work%20Content/)
+- [Publications](/publications.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,35 +12,35 @@ free to add sections and subsections to this sidebar.)
 &nbsp;&nbsp;**Components**
 
 - [Connector](/submodule/Connector/)
-  - [Developer](/submodule/Connector/docs/developer/)
+  - [Documentation](/submodule/Connector/docs/developer/)
   - [Decision Records](/submodule/Connector/docs/developer/decision-records/)
 
 - [Data Dashboard](/submodule/DataDashboard/)
-  - [Developer](/submodule/DataDashboard/docs/developer/)
+  - [Documentation](/submodule/DataDashboard/docs/developer/)
   - [Decision Records](/submodule/DataDashboard/docs/developer/decision-records/)
 
 - [Federated Catalog](/submodule/FederatedCatalog/)
-  - [Developer](/submodule/FederatedCatalog/docs/developer/)
+  - [Documentation](/submodule/FederatedCatalog/docs/developer/)
   - [Decision Records](/submodule/FederatedCatalog/docs/developer/decision-records/)
 
 - [Gradle Plugins](/submodule/GradlePlugins/)
-  - [Developer](/submodule/GradlePlugins/docs/developer/)
+  - [Documentation](/submodule/GradlePlugins/docs/developer/)
   - [Decision Records](/submodule/GradlePlugins/docs/developer/decision-records/)
 
 - [Identity Hub](/submodule/IdentityHub/)
-  - [Developer](/submodule/IdentityHub/docs/developer/)
+  - [Documentation](/submodule/IdentityHub/docs/developer/)
   - [Decision Records](/submodule/IdentityHub/docs/developer/decision-records/)
 
 - [Minimum Viable Dataspace](/submodule/MinimumViableDataspace/)
-  - [Developer](/submodule/MinimumViableDataspace/docs/developer/)
+  - [Documentation](/submodule/MinimumViableDataspace/docs/developer/)
   - [Decision Records](/submodule/MinimumViableDataspace/docs/developer/decision-records/)
 
 - [Registration Service](/submodule/RegistrationService/)
-  - [Developer](/submodule/RegistrationService/docs/developer/)
+  - [Documentation](/submodule/RegistrationService/docs/developer/)
   - [Decision Records](/submodule/RegistrationService/docs/developer/decision-records/)
 
 - [Trust Framework Adoption](/submodule/TrustFrameworkAdoption/)
-  - [Developer](/submodule/TrustFrameworkAdoption/docs/developer/)
+  - [Documentation](/submodule/TrustFrameworkAdoption/docs/developer/)
   - [Decision Records](/submodule/TrustFrameworkAdoption/docs/developer/decision-records/)
 
 &nbsp;&nbsp;**Documents**

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
 
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css" title="vue"/>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/sidebar.min.css" />
+    <link rel="stylesheet" href="style/sidebar.css" />
 
     <style>
       nav.app-nav li ul {

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,10 @@
     <link rel="icon" href="_media/favicon.ico" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
+
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css" title="vue"/>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/sidebar.min.css" />
+
     <style>
       nav.app-nav li ul {
         min-width: 100px;
@@ -66,15 +69,19 @@
         topMargin: 100,
       };
     </script>
+
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/emoji.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/zoom-image.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/docsify-pagination/dist/docsify-pagination.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-pagination/dist/docsify-pagination.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-updated/src/time-updater.min.js"></script>
 
     <script src="//unpkg.com/docsify-remote-markdown/dist/docsify-remote-markdown.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/front-matter.min.js"></script>
+
   </body>
 </html>

--- a/docs/style/sidebar.css
+++ b/docs/style/sidebar.css
@@ -1,0 +1,33 @@
+.sidebar-nav {
+    position: relative;
+    margin-left: 10px;
+    cursor: pointer
+}
+
+.sidebar-nav li {
+    position: relative;
+    margin-left: 5px;
+    cursor: pointer
+}
+
+.sidebar-nav ul:not(.app-sub-sidebar) > li:not(.file)::before {
+    position: absolute;
+    content: '';
+    display: block;
+    top: 12px;
+    left: -15px;
+    height: 6px;
+    width: 6px;
+    border-right: 1px solid #505d6b;
+    border-bottom: 1px solid #505d6b;
+    transform: rotate(-45deg);
+    transition: transform .1s
+}
+
+.sidebar-nav ul:not(.app-sub-sidebar) > li.open::before {
+    transform: rotate(45deg)
+}
+
+.sidebar-nav ul:not(.app-sub-sidebar) > li.collapse::before {
+    transform: rotate(-45deg)
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds `Developer` and `Decision Records` links for every component in the sidebar.
e.g.
![Screenshot_20230817_122833](https://github.com/eclipse-edc/docs/assets/8570990/ee11f0ef-09ff-4342-b085-f2b4070b3e7d)

## Why it does that

Improve browsability.

## Further notes

- converted the _sidebar.md file to pure markdown, it seems to work fine.
- added the [docsify-sidebar-collapse](https://www.npmjs.com/package/docsify-sidebar-collapse) plugin to have a more readable menu

## Linked Issue(s)

Closes #82 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
