### PR TITLE
docs: add chapter about transferprocesses

### DIFF
--- a/developer/handbook.md
+++ b/developer/handbook.md
@@ -665,7 +665,8 @@ The Management API provides several endpoints to manipulate data transfers.
 
 A data destination is a description of where the consumer expects to find the data after the transfer completes. In a "
 provider-push" scenario this could be an object storage container, a directory on a file system, etc. In a
-"consumer-pull" scenario this could be an API endpoint from which the consumer wants to fetch the data.
+"consumer-pull" scenario this would be a placeholder, that does not contain any information about the destination, as
+the provider "decides" on which endpoint he makes the data available.
 
 A data address is a schemaless object, and the provider and the consumer need to have a common understanding of the
 required fields. For example, if the provider is supposed to put the data into a file share, the `DataAddress` object
@@ -677,7 +678,7 @@ sinks"). Thus, the way to establish that "understanding" is to make sure that bo
 sinks. That means, if a consumer asks to put the data in a file share, the provider must have the appropriate data plane
 extensions to be able to perform that transfer.
 
-If either side does _not_ have the appropriate extensions loaded at runtime, the transfer process will fail.
+If the provider connector does _not_ have the appropriate extensions loaded at runtime, the transfer process will fail.
 
 ##### Using event callbacks
 
@@ -710,6 +711,7 @@ they must be specified when requesting to initiate the transfer:
 ```
 
 Currently, we support the following events:
+
 - `transfer.process.deprovisioned`
 - `transfer.process.completed`
 - `transfer.process.deprovisioningRequested`
@@ -721,7 +723,7 @@ Currently, we support the following events:
 - `transfer.process.terminated`
 
 The connector's event dispatcher will send invoke the webhook specified in the `uri` field passing the event
-payload as JSON object. 
+payload as JSON object.
 
 #### Expressing queries with a `Criterion`
 

--- a/developer/handbook.md
+++ b/developer/handbook.md
@@ -640,18 +640,24 @@ connector.
 
 #### Transfer processes
 
-A `TransferProcess` is a record of the data sharing procedure between a _consumer_ and a _provider_. It percolates
-through several states (`TransferProcessStates`).
+A `TransferProcess` is a record of the data sharing procedure between a _consumer_ and a _provider_. As they traverse
+through the system, they transition through several
+states (`TransferProcessStates`, [source](https://github.com/eclipse-edc/Connector/blob/main/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcessStates.java)).
 
-Once a contract is [negotiated](#contract-negotiations)) and an agreement is [reached](#contract-agreements), the
-consumer connector may send a transfer initiate request (more on that [here](#control-plane-state-machines)). Both
-parties may provision additional resources, for example deploying a temporary object store, where the provider should
-put the data. Similarly, the provider may need to take some preparatory steps, e.g. anonymizing the data.
+Once a contract is [negotiated](#contract-negotiations)) and an [agreement is reached](#contract-agreements), the
+consumer connector may send a transfer initiate request (more on that [here](#control-plane-state-machines)) to start
+the transfer. In the course of doing that, both parties may provision additional resources, for example deploying a
+temporary object store, where the provider should put the data. Similarly, the provider may need to take some
+preparatory steps, e.g. anonymizing the data before sending it out.
 
-This is sometimes referred to as the _provisioning phase_.
+This is sometimes referred to as the _provisioning phase_. If no additional provisioning is needed, the transfer process
+simply transitions through the state with a NOOP.
 
-Once that is done, the transfer begins in earnest, according to the `dataDestination`, that was passed in the initiate
-request.
+Once that is done, the transfer begins in earnest. Data is transmitted according to the `dataDestination`, that was
+passed in the initiate-request.
+
+Once the transmission has completed, the transfer process will transition to the `COMPLETED` state, or - if an error
+occurred - to the `TERMINATED` state.
 
 The Management API provides several endpoints to manipulate data transfers.
 
@@ -669,13 +675,11 @@ need to be "aware" of that.
 The actual data transfer is handled by a [data plane](#the-data-plane) through extensions (called "sources" and "
 sinks"). Thus, the way to establish that "understanding" is to make sure that both parties have matching sources and
 sinks. That means, if a consumer asks to put the data in a file share, the provider must have the appropriate data plane
-extensions to be able to perform that transfer. 
+extensions to be able to perform that transfer.
 
-If either side does _not_ have the appropriate extensions loaded at runtime, the transfer process will fail. 
+If either side does _not_ have the appropriate extensions loaded at runtime, the transfer process will fail.
 
 ##### Using event callbacks
-
-
 
 #### Expressing queries with a `Criterion`
 

--- a/developer/handbook.md
+++ b/developer/handbook.md
@@ -640,6 +640,43 @@ connector.
 
 #### Transfer processes
 
+A `TransferProcess` is a record of the data sharing procedure between a _consumer_ and a _provider_. It percolates
+through several states (`TransferProcessStates`).
+
+Once a contract is [negotiated](#contract-negotiations)) and an agreement is [reached](#contract-agreements), the
+consumer connector may send a transfer initiate request (more on that [here](#control-plane-state-machines)). Both
+parties may provision additional resources, for example deploying a temporary object store, where the provider should
+put the data. Similarly, the provider may need to take some preparatory steps, e.g. anonymizing the data.
+
+This is sometimes referred to as the _provisioning phase_.
+
+Once that is done, the transfer begins in earnest, according to the `dataDestination`, that was passed in the initiate
+request.
+
+The Management API provides several endpoints to manipulate data transfers.
+
+##### About Data Destinations
+
+A data destination is a description of where the consumer expects to find the data after the transfer completes. In a "
+provider-push" scenario this could be an object storage container, a directory on a file system, etc. In a
+"consumer-pull" scenario this could be an API endpoint from which the consumer wants to fetch the data.
+
+A data address is a schemaless object, and the provider and the consumer need to have a common understanding of the
+required fields. For example, if the provider is supposed to put the data into a file share, the `DataAddress` object
+representing the data destination will likely contain the host URL, a path and possibly a file name. So both connectors
+need to be "aware" of that.
+
+The actual data transfer is handled by a [data plane](#the-data-plane) through extensions (called "sources" and "
+sinks"). Thus, the way to establish that "understanding" is to make sure that both parties have matching sources and
+sinks. That means, if a consumer asks to put the data in a file share, the provider must have the appropriate data plane
+extensions to be able to perform that transfer. 
+
+If either side does _not_ have the appropriate extensions loaded at runtime, the transfer process will fail. 
+
+##### Using event callbacks
+
+
+
 #### Expressing queries with a `Criterion`
 
 A `Criterion` is a normalized way of expressing a logical requirement between two operands and an operator. For example,


### PR DESCRIPTION
## What this PR changes/adds

Adds a chapter about Transfer Processes to the handbook.

## Why it does that

documentation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
