### PR TITLE
chore: configure EDC bot

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -29,6 +29,9 @@ jobs:
           branch: ${{ env.NEW_BRANCH }}
           create_branch: true
           commit_message: ${{ env.COMMIT_MESSAGE }}
+          commit_user_name: eclipse-edc-bot
+          commit_user_email: edc-bot@eclipse.org
+          commit_author: eclipse-edc-bot <edc-bot@eclipse.org>
       - name: Create a pull request
         id: create_a_pull_request
         uses: vsoch/pull-request-action@master


### PR DESCRIPTION
## What this PR changes/adds

Adds the EDC bot (configuration from https://github.com/eclipse-edc/.github/blob/main/.github/actions/bump-version/action.yml).

## Why it does that

The ECA check fails for GH Actions bot:
![image](https://github.com/eclipse-edc/docs/assets/72392527/78ce1d88-d6cc-4693-b339-64df38815066)

## Further notes

See [here](https://github.com/stefanzweifel/git-auto-commit-action#usage) for the action's guide.

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
