### PR TITLE
fix: fix dead links related to .github resources

### DIFF
--- a/contributing/adoption.md
+++ b/contributing/adoption.md
@@ -55,4 +55,4 @@ Note that even if all the aforementioned points are answered satisfactorily, **t
 
 ## Submitting an application
 
-Please open in issue using the [adoption request](../docs/submodule/GitHub/contributing/adoption.md) template, fill out all the sections to the best of your knowledge and wait to hear back from the EDC core team. We will comment in the issue, or reach out to you directly. Be aware that omitting sections from the application will greatly diminish the chance of approval.
+Please open in issue using the [adoption request](../docs/submodule/GitHub/.github/ISSUE_TEMPLATE/adoption_request.md) template, fill out all the sections to the best of your knowledge and wait to hear back from the EDC core team. We will comment in the issue, or reach out to you directly. Be aware that omitting sections from the application will greatly diminish the chance of approval.

--- a/contributing/pr_etiquette.md
+++ b/contributing/pr_etiquette.md
@@ -34,7 +34,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
   - The title must follow the format as `<type>(<optional scope>): <description>`.
     `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` are allowed for the `<type>`.
   - The length must be kept under 80 characters.
-  - See [check-pull-request-title job of GitHub workflow](../docs/submodule/GitHub/.github/workflows/scan-pull-request.yml) for checking details.
+  - See [check-pull-request-title job of GitHub workflow](https://github.com/eclipse-edc/.github/blob/main/.github/workflows/scan-pull-request.yml) for checking details.
 
 ## As a reviewer
 


### PR DESCRIPTION
## What this PR changes/adds

* updated the path to adoption request temlpate.
* made link to scan-pull-request.yml external since docsify can not render the local .yml file.


## Linked Issue(s)

Closes #130 
