### PR TITLE
docs: add links for connector autodoc and openapi ui

### DIFF
--- a/developer/handbook.md
+++ b/developer/handbook.md
@@ -199,9 +199,7 @@ what conditions.
 > specifications for [ODRL](https://www.w3.org/TR/odrl-model/) and [DCAT](https://www.w3.org/TR/vocab-dcat-2/).
 
 
-> The complete OpenAPI specification for the management API is
-> on [SwaggerHub](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api). Please select the latest version from
-> the dropdown.
+> The complete OpenAPI specification for the management API can be found [here](https://eclipse-edc.github.io/Connector/openapi/management-api/).
 
 #### Assets
 
@@ -474,7 +472,7 @@ public class HeadquarterPolicyExtension implements ServiceExtension {
 Let's accept for now, that `@Inject` is how [EDC achieves dependency injection](#edc-dependency-injection).
 This example assumes, a policy object exists in the system, that has a `leftOperand = headquarter_function`. For details
 on how to create policies, please check out
-the [OpenAPI documentation](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api/0.2.1#/Policy%20Definition/createPolicyDefinition).
+the [OpenAPI documentation](https://eclipse-edc.github.io/Connector/openapi/management-api/#/Policy%20Definition/createPolicyDefinition).
 
 ##### Advanced policy concepts
 
@@ -607,7 +605,7 @@ The current state of the negotiation can be queried and altered through the mana
 
 
 Please check out
-the [OpenAPI documentation](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api/0.2.1#/Policy%20Definition/createPolicyDefinition)
+the [OpenAPI documentation](https://eclipse-edc.github.io/Connector/openapi/management-api/#/Policy%20Definition/createPolicyDefinition)
 for an exemplary request to initiate a negotiation. The `callbackAddresses` object is optional and can be used to get
 notified about state changes of the negotiation. Read more on callbacks in the section
 about [events and callbacks](#events-and-callbacks).
@@ -688,7 +686,7 @@ you may also run into rate-limiting situations, if the connector is behind a loa
 recommend using event callbacks.
 
 As shown in
-the [OpenAPI documentation](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api/0.3.1#/Transfer%20Process/initiateTransferProcess)
+the [OpenAPI documentation](https://eclipse-edc.github.io/Connector/openapi/management-api/#/Transfer%20Process/initiateTransferProcess)
 they must be specified when requesting to initiate the transfer:
 
 ```json

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,6 +14,13 @@ free to add sections and subsections to this sidebar.)
 - [Connector](/submodule/Connector/)
   - [Documentation](/submodule/Connector/docs/developer/)
   - [Decision Records](/submodule/Connector/docs/developer/decision-records/)
+  - [Modules](https://eclipse-edc.github.io/Connector/autodoc/)
+  - Api
+    - [Management](https://eclipse-edc.github.io/Connector/openapi/management-api/)
+    - [Observability](https://eclipse-edc.github.io/Connector/openapi/observability-api/)
+    - [Control](https://eclipse-edc.github.io/Connector/openapi/control-api/)
+    - [DSP](https://eclipse-edc.github.io/Connector/openapi/dsp-api/)
+    - [Public](https://eclipse-edc.github.io/Connector/openapi/public-api/)
 
 - [Data Dashboard](/submodule/DataDashboard/)
   - [Documentation](/submodule/DataDashboard/docs/developer/)
@@ -54,4 +61,3 @@ free to add sections and subsections to this sidebar.)
 &nbsp;&nbsp;**Links**
 
 - [Known Friends](/documentation/KNOWN_FRIENDS.md)
-- [SwaggerHub](https://app.swaggerhub.com/search?owner=eclipse-edc-bot)

--- a/docs/hands-on.md
+++ b/docs/hands-on.md
@@ -5,6 +5,4 @@
 - [Samples repository](samples/)
 
 Links:
-- [Management API Specification (SwaggerHub)](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api)
-- [Control API Specification (SwaggerHub)](https://app.swaggerhub.com/apis/eclipse-edc-bot/control-api)
 - [YouTube Playlist](https://youtube.com/playlist?list=PLw-f_YoTxWJVVPkuj1vDb6tLPM2_Cm1hR)


### PR DESCRIPTION
## What this PR changes/adds

Add links to see the github-pages hosted documentation about modules and openapi.
In the menu they will be more visible than to be in the hands-on page, and this way every component will have their own generated documentation
Preview:
![Screenshot_20240328_100455](https://github.com/eclipse-edc/docs/assets/8570990/ed73f3fb-2bdc-48e4-b398-e4034dfbb815)

## Why it does that

documentation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
