### PR TITLE
docs: add decision record about repo separation

### DIFF
--- a/developer/decision-records/2024-04-19-tech-repo-split/README.md
+++ b/developer/decision-records/2024-04-19-tech-repo-split/README.md
@@ -1,4 +1,4 @@
-# Decision: separation build pipelines for Technology Repositories
+# Decision: Separate build pipelines for Technology Repositories
 
 ## Definition of terms
 
@@ -11,8 +11,8 @@ For the purposes of this document, the following definition of terms apply:
 
 ## Decision
 
-We will separate the build and release pipelines for the technology repositories. That means, that continuous builds,
-nightly builds and release builds can technically happen separate from the core components builds.
+We will separate the build and release pipelines for the technology repositories. That means continuous builds,
+nightly builds, and release builds can technically happen separately from the core components builds.
 
 To achieve that, every technology repository will get its own Maven sub-group-id:
 

--- a/developer/decision-records/2024-04-19-tech-repo-split/README.md
+++ b/developer/decision-records/2024-04-19-tech-repo-split/README.md
@@ -1,10 +1,21 @@
-# Decision separation build pipelines for Technology Repositories
+# Decision: separation build pipelines for Technology Repositories
+
+## Definition of terms
+
+For the purposes of this document, the following definition of terms apply:
+
+- "technology": refers to code in EDC extensions implementing specific services of a particular CSP, for
+  example Amazon S3
+- "technology repository": EDC repositories that host these technology extension.
+- CSP: cloud solution provider, such as Microsoft (Azure), Google (GCP) or Amazon (AWS)
 
 ## Decision
 
-We will separate the build and release pipelines for the Technology-* repositories. That means, that continuous builds, nightly builds and release builds can technically happen separate from the core components builds.
+We will separate the build and release pipelines for the technology repositories. That means, that continuous builds,
+nightly builds and release builds can technically happen separate from the core components builds.
 
-To achieve that, every technolgy repo will get its own Maven sub-group-id: 
+To achieve that, every technology repository will get its own Maven sub-group-id:
+
 - Technology-Azure: `org.eclipse.edc.azure`
 - Technology-Aws: `org.eclipse.edc.aws`
 - Technology-Gcp: `org.eclipse.edc.gcp`
@@ -12,20 +23,25 @@ To achieve that, every technolgy repo will get its own Maven sub-group-id:
 
 As a convention, the version numbering across _all_ repositories will remain consistent.
 
-
 ## Rationale
 
-Maintenance and upkeep for the Technology repositories is currently handled by the committers of the EDC project, for whom this has become a substantial time and resources investment.
-In an effort to re-allocate these resources to the core components, we want to decouple the release processes of the Technology repositories. That way, when the builds fail, for example due to a breaking change in an SPI, or some other compile-time problem, the release of the core components is not blocked.
+Maintenance and upkeep for the technology repositories is currently handled by the committers of the EDC project, for
+whom this has become a substantial time and resources investment.
+In an effort to re-allocate these resources to the core components, we want to decouple the release processes of the
+Technology repositories. That way, when the builds fail, for example due to a breaking change in an SPI, or some other
+compile-time or run-time problem, the release of the core components is not blocked.
 
-In addition, a process should be started to create dedicated specialist teams in those cloud provider companies, who over time build trust with the community and gain traction with the project, so that they can eventually take over the maintenance for the Technology repositories. This will also help bolster and foster the community of EDC.
+In addition, a process should be started to create dedicated specialist teams in those cloud provider companies, who
+over time build trust with the community and gain traction with the project, so that they can eventually take over the
+maintenance for the technology repositories. This will also help bolster and foster the community of EDC.
 
 It is understood that that is a lengthy process, but one that should start sooner rather than later.
 
 ## Approach
 
 Several things are necessary to achieve that modularization:
-- removing the Technology repositories from the build scripts in the Release repository. This will exclude them from the nightly and release builds.
+
+- removing the technology repositories from the build scripts in the Release repository. This will exclude them from the
+  nightly and release builds.
 - add Maven sub-group-ids
 - create a GitHub workflow that publishes to OSSRH Staging / MavenCentral, bumps versions, etc.
-- 

--- a/developer/decision-records/2024-04-19-tech-repo-split/README.md
+++ b/developer/decision-records/2024-04-19-tech-repo-split/README.md
@@ -1,0 +1,31 @@
+# Decision separation build pipelines for Technology Repositories
+
+## Decision
+
+We will separate the build and release pipelines for the Technology-* repositories. That means, that continuous builds, nightly builds and release builds can technically happen separate from the core components builds.
+
+To achieve that, every technolgy repo will get its own Maven sub-group-id: 
+- Technology-Azure: `org.eclipse.edc.azure`
+- Technology-Aws: `org.eclipse.edc.aws`
+- Technology-Gcp: `org.eclipse.edc.gcp`
+- (Technology-Huawei: `org.eclipse.edc.huawei`)
+
+As a convention, the version numbering across _all_ repositories will remain consistent.
+
+
+## Rationale
+
+Maintenance and upkeep for the Technology repositories is currently handled by the committers of the EDC project, for whom this has become a substantial time and resources investment.
+In an effort to re-allocate these resources to the core components, we want to decouple the release processes of the Technology repositories. That way, when the builds fail, for example due to a breaking change in an SPI, or some other compile-time problem, the release of the core components is not blocked.
+
+In addition, a process should be started to create dedicated specialist teams in those cloud provider companies, who over time build trust with the community and gain traction with the project, so that they can eventually take over the maintenance for the Technology repositories. This will also help bolster and foster the community of EDC.
+
+It is understood that that is a lengthy process, but one that should start sooner rather than later.
+
+## Approach
+
+Several things are necessary to achieve that modularization:
+- removing the Technology repositories from the build scripts in the Release repository. This will exclude them from the nightly and release builds.
+- add Maven sub-group-ids
+- create a GitHub workflow that publishes to OSSRH Staging / MavenCentral, bumps versions, etc.
+- 

--- a/developer/decision-records/README.md
+++ b/developer/decision-records/README.md
@@ -22,6 +22,8 @@
 - [2023-06-19 Onboarding Contributors](2023-06-19-onboarding-contributors/)
 - [2023-07-06 Committer Retirements](2023-07-06-committer-retirement/)
 - [2023-09-06 Identity and Trust](2023-09-06-identity-trust/)
+- [2023-09-12 Publishing from GitHub](2023-09-12-publishing_from_github/)
+- [2024-04-19 Separating Release process of Technology repos](2024-04-19-tech-repo-split/)
 
 ## Repository-specific
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a decision record about separating the release process of our technology repos

## Why it does that


Make decisions transparent

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
