### PR TITLE
refactor: remove RegistrationService

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "docs/submodule/Publications"]
 	path = docs/submodule/Publications
 	url = https://github.com/eclipse-edc/Publications.git
-[submodule "docs/submodule/RegistrationService"]
-	path = docs/submodule/RegistrationService
-	url = https://github.com/eclipse-edc/RegistrationService.git
 [submodule "docs/submodule/GradlePlugins"]
 	path = docs/submodule/GradlePlugins
 	url = https://github.com/eclipse-edc/GradlePlugins.git
@@ -34,6 +31,7 @@
 [submodule "docs/documentation"]
 	path = docs/documentation
 	url = https://github.com/eclipse-edc/docs.git
+	shallow = true
 [submodule "docs/samples"]
 	path = docs/samples
 	url = https://github.com/eclipse-edc/Samples.git

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -43,10 +43,6 @@ free to add sections and subsections to this sidebar.)
   - [Documentation](/submodule/MinimumViableDataspace/docs/developer/)
   - [Decision Records](/submodule/MinimumViableDataspace/docs/developer/decision-records/)
 
-- [Registration Service](/submodule/RegistrationService/)
-  - [Documentation](/submodule/RegistrationService/docs/developer/)
-  - [Decision Records](/submodule/RegistrationService/docs/developer/decision-records/)
-
 - [Trust Framework Adoption](/submodule/TrustFrameworkAdoption/)
   - [Documentation](/submodule/TrustFrameworkAdoption/docs/developer/)
   - [Decision Records](/submodule/TrustFrameworkAdoption/docs/developer/decision-records/)


### PR DESCRIPTION
## What this PR changes/adds

Removed references about the archived project [RegistrationService](https://github.com/eclipse-edc/RegistrationService)

## Why it does that

cleanup

## Further notes

- added `shallow = true` on the documentation self submodule, to avoid recursive fetch.

## Linked Issue(s)

Closes #155 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
