### PR TITLE
docs: add DR for technology repositories release

### DIFF
--- a/developer/decision-records/2024-08-13-technology-repos-release/README.md
+++ b/developer/decision-records/2024-08-13-technology-repos-release/README.md
@@ -1,0 +1,45 @@
+# Technology Repositories Release
+
+## Decision
+
+Release of a "Technology" repository need a separate and well-defined release process.
+
+## Rationale
+
+"Technology" repository release happens after the completion of the "core" release. This is true both for new releases
+and bugfixes.
+
+## Approach
+
+The process will slightly differ between:
+- `release` (new features with a `x.y.0` version number)
+- `bugfix` (only bugfix with a `x.y.z` version number, with `z` greater than 0, starting from a previously existing release branch)
+
+### Prepare release
+There will be a `prepare-release` job on every `Technology` repo with these inputs:
+- version number to be released
+- starting branch (`main` by default)
+
+The workflow will:
+- set the core dependency version number to the one passed in input
+- set the project version number to the one passed in input
+- create a temporary `prepare/x.y.z` branch
+- commit
+- create a PR from `prepare/x.y.z` to `release|bugfix/x.y.z`
+
+The PR will take care to run all the checks (tests, dependencies, ...) and will give to the committers the opportunity to
+eventually cherry-pick commits for a `bugfix` release.
+
+### Release
+
+When the preparation PR gets merged there will be an automated workflow that gets triggered on push on a `release/` or `bugfix/` branch.
+Such flow will:
+- publish artifacts on maven central
+- create `vx.y.z` git tag
+- create github release
+- send a message on the discord channel.
+- \[only for `release`, not for `bugfix`\] bump version to next snapshot
+
+note that the `releases` branch is not involved by this process. In fact, at this point it does not make sense to maintain it.
+
+These workflows will be created as reusable in the `.github` repository and then referenced in every `Technology` repository.

--- a/developer/decision-records/README.md
+++ b/developer/decision-records/README.md
@@ -24,8 +24,9 @@
 - [2023-09-06 Identity and Trust](2023-09-06-identity-trust/)
 - [2023-09-12 Publishing from GitHub](2023-09-12-publishing_from_github/)
 - [2024-04-19 Separating Release process of Technology repos](2024-04-19-tech-repo-split/)
-- [2024-05-27 EDC Maturity Levels and Deprecation Policy](2024-05-27-maturity-levels-deprecation-policy)
-- [2024-07-17 Bootstrapping SQL Databases](2024-07-17-bootstrap-sql-database)
+- [2024-05-27 EDC Maturity Levels and Deprecation Policy](2024-05-27-maturity-levels-deprecation-policy/)
+- [2024-07-17 Bootstrapping SQL Databases](2024-07-17-bootstrap-sql-database/)
+- [2024-08-13 Technology Repositories Release](2024-08-13-technology-repos-release/)
 
 ## Repository-specific
 


### PR DESCRIPTION
## What this PR changes/adds

Adds decision record about the new release process for `Technology` repositories

## Why it does that

documentation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
