### PR TITLE
chore(docs): add links to data plane signaling

### DIFF
--- a/developer/wip/for-contributors/contributor-handbook.md
+++ b/developer/wip/for-contributors/contributor-handbook.md
@@ -194,15 +194,13 @@ Detailed documentation about EDCs PostgreSQL implementations can be found [here]
 
 ### 4.1 Data plane signaling
 
-Data Plane Signaling (DPS) is the communication protocol that is used between control planes and data planes.  
+Data Plane Signaling (DPS) is the communication protocol that is used between control planes and data planes. Detailed
+information about it and other topics such as data plane self-registration and public API authentication can be found
+[here](./data-plane/data-plane-signaling/data-plane-signaling.md).
 
-### 4.2 Data plane self-registration
+### 4.2 Writing a custom data plane extension (sink/source)
 
-### 4.3 Public API authentication
-
-### 4.4 Writing a custom data plane extension (sink/source)
-
-### 4.5 Writing a custom data plane (using only DPS)
+### 4.3 Writing a custom data plane (using only DPS)
 
 ## 5. Development best practices
 


### PR DESCRIPTION
## What this PR changes/adds

adds links to sub-documents from the dataplane signaling chapter in the main contributor doc

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
